### PR TITLE
now events pass then action as parametter

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -64,7 +64,7 @@ class Store extends EventEmitter {
 				let clone = Store.clone(trans.newState);
 				_state = clone;
 				_stateclone = Store.clone(clone);
-				return this.emit(action.type, _stateclone);
+				return this.emit(action.type, _stateclone, action);
 			} else {
 				this.emit(action.type, action);
 				return void 0;


### PR DESCRIPTION
On event listeners you couldn't have the action dispatched which we needed to append items to collections, this small change allows it:

![image](https://user-images.githubusercontent.com/10210792/39718068-c90b156c-51fa-11e8-997e-a25e077ed304.png)
