### PR TITLE
metacomponents ghost listeners

### DIFF
--- a/__tests__/metaviews.js
+++ b/__tests__/metaviews.js
@@ -184,3 +184,29 @@ test('MetaShadowComponent should have Links tags from the styles property', () =
 	const style = el.querySelector('style')
 	expect(style).toBeInstanceOf(HTMLStyleElement);
 })
+
+test('MetaBase should remove store listener on Component Dismount', () => {
+	storage = new Store({val: 1}, { 'INCREMENT': (a, s) => { s.val++; return {newState: s} } })
+	let fn = jest.fn();
+	class rmComponent extends MetaComponent {
+		constructor() {
+			super(storage);
+			this.styles = [];
+		}
+		render() {
+			this.content = Div({}, this.storage.getState().val);
+			return 'this.content';
+		}
+		handleStoreEvents() {
+			return {
+				'INCREMENT': fn
+			}
+		}
+	}
+	DefineElement('rm-component', rmComponent);
+	let el = RmComponent();
+	document.body.appendChild(el);
+	document.body.removeChild(el);
+	storage.dispatch({ type: 'INCREMENT' });
+	expect(fn).not.toHaveBeenCalled();
+});

--- a/docs/_posts/2020-12-03-V2.0.2 copy.markdown
+++ b/docs/_posts/2020-12-03-V2.0.2 copy.markdown
@@ -10,3 +10,8 @@ Fix bug where elements that are not in the HTML tree keep listening to store eve
 
 ## Fix syntax issue with HTMLElementCreator.
 Yes, with a long name like that no wonder why is tedious to use the core of the custom elements, but the fact that you always have to pass empty props if you want an empty element doesn't really help, in this patch, the props parameters are no longer mandatory.
+
+## Fix handleStoreEvents in Class components
+Fix an issue where the listeners will keep existing even if the elements were removed from the DOM.
+Now the listeners are removed ```onDisconectedCallback```.
+

--- a/docs/blog.md
+++ b/docs/blog.md
@@ -7,7 +7,7 @@ author: Osmar Reyes
 
 # Metaflux blog Overview
 
-Welcome to the blog for Metaflux, here the dev team will be leaving theit thoughts, ideas or just some explination, the obstacles and here you will be able to see the core, the hard of the beast, as we update this library will highlight pieces of code, sketches or diagrams that help us to conquer our goal.
+Welcome to the blog for Metaflux, here the dev team will be leaving their thoughts, ideas, or just some explanation, the obstacles, and here you will be able to see the core, the heart of the beast, as we update this library will highlight pieces of code, sketches or diagrams that help us to conquer our goal.
 
 We love this community, that's why Metaflux is open source, we want you to get involved, to help us improve, perhaps report a bug in our [repository](https://github.com/rebelstackio/metaflux), or just forked and play with it and if you can improve something you can feel free to create a pull request, connect to our [discord](https://discord.gg/HmuBCRb) channel and pitch your ideas. 
 

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -122,7 +122,7 @@ window.customElements.define('sort-table', SortTable);
 // get container element
 const _cont = document.querySelector('#container');
 // create new table
-const _table = document.createElement('sort-table');
+const _table = HTMLElementCreator('sort-table');
 // append it to the container
 _cont.appendChild(_table);
 ```

--- a/lib/metaviews/meta-base.js
+++ b/lib/metaviews/meta-base.js
@@ -63,6 +63,19 @@ class MetaBase extends window.HTMLElement {
 	ComponentDidFail(error) {
 		throw error
 	}
+	/**
+	 * customElement disconected callback
+	 */
+	disconnectedCallback() {
+		const events = this.storage ? this.handleStoreEvents() : {};
+		for (const eventType in events) {
+			// remove listeners on disconected
+			/* eslint-disable no-prototype-builtins */
+			if (events.hasOwnProperty(eventType)) {
+				this.storage.removeListener(eventType, events[eventType]);
+			}
+		}
+	}
 }
 
 module.exports = {


### PR DESCRIPTION
## Ghost listeners in MetaComponents and MetashadowComponents
- Fix issue where the listeners in the handleStoreEvents life cycle function keep existing after the element was removed from the DOM. this could lead to major memory leaks in a SPA env. Check [here](https://codepen.io/osszzyy/pen/zYKBdNo) to recreate the error.
- Update docs, fix typos.

### MetaBase now handle disconnected element.
add ```disconnectedCallback``` to handle remove handleStoreEvents listeners.
```js
disconnectedCallback() {
	const events = this.storage ? this.handleStoreEvents() : {};
	for (const eventType in events) {
		// remove listeners on disconected
		/* eslint-disable no-prototype-builtins */
		if (events.hasOwnProperty(eventType)) {
			this.storage.removeListener(eventType, events[eventType]);
		}
	}
}
```